### PR TITLE
Register enums as a string

### DIFF
--- a/src/Barryvdh/MigrationGenerator/MigrationGeneratorCommand.php
+++ b/src/Barryvdh/MigrationGenerator/MigrationGeneratorCommand.php
@@ -70,6 +70,8 @@ class MigrationGeneratorCommand extends Command
         $fields = array();
 
         $schema = \DB::getDoctrineSchemaManager($table);
+        
+        $schema->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
         $indexes = $schema->listTableIndexes($table);
         foreach ($indexes as $index) {


### PR DESCRIPTION
Doctrine doesn't handle `enum` almost at all, which will cause the script to throw an Exception when encountering an enum field.

This maps enum to be a `string`. This results in the generated migration being for a `string`, but it's easier to go in and patch that up, than having it just not work at all.
