### PR TITLE
Adding registered types and field type mappings to command line options

### DIFF
--- a/src/Barryvdh/MigrationGenerator/MigrationGeneratorServiceProvider.php
+++ b/src/Barryvdh/MigrationGenerator/MigrationGeneratorServiceProvider.php
@@ -35,8 +35,9 @@ class MigrationGeneratorServiceProvider extends ServiceProvider {
         {
             $cache = new Cache($app['files']);
             $generator = new Generators\MigrationGenerator($app['files'], $cache);
+            $config = $app['config']->get('laravel-migration-generator::config');
 
-            return new MigrationGeneratorCommand($generator);
+            return new MigrationGeneratorCommand($generator,$config);
         });
         $this->commands('command.migration-generator');
 	}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,38 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Register Types
+    |--------------------------------------------------------------------------
+    |
+    | Doctrine does not support a number of field types. Use this array to map
+    | possible field types to their supported alternatives.
+    |
+    */
+
+    'registerTypes' => array(
+        'enum' => 'string',
+        'bit' => 'boolean'
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Field Type Map
+    |--------------------------------------------------------------------------
+    |
+    | Used to convert certain field types and cast them as another. Similar to
+    | the registered types, but are not registered by Doctrine and are simply
+    | converted as columns are read.
+    |
+    */
+
+    'fieldTypeMap' => array(
+        'guid' => 'string',
+        'bigint' => 'integer',
+        'littleint' => 'integer',
+        'datetimetz' => 'datetime'
+    )
+
+);


### PR DESCRIPTION
Adds the following command line options:

--register-types=type1:value,type2:value
--type-map=type1:value,type2:value

This allows the user to specify additional doctrine types to register as well as convert additional field types. 
